### PR TITLE
Fixed the picker button being a submit

### DIFF
--- a/src/core/FontPicker.ts
+++ b/src/core/FontPicker.ts
@@ -95,6 +95,7 @@ export class FontPicker extends EventEmitter<{
         config.font = this.$el.value
       }
       const $wrap = document.createElement('button')
+      $wrap.setAttribute('type', 'button');
       this.$el.after($wrap)
 
       this.$inputEl = this.$el


### PR DESCRIPTION
Thank you for this great package!

I noticed that the button created by jsfontpicker is missing a `type` attribute. Because of that, when used in a `<form>`, it submits the form when clicked, and takes over the `Enter` key presses from other form inputs.

:warning: Note that this PR does not update the `dist` directory, as the commands I found in the npm scripts seems to remove the dist (min) files rather than rebuild it. Please let me know the right way to do it, and I'll update this PR.